### PR TITLE
feat: add Pydantic BaseModel serialization support

### DIFF
--- a/src/surrantic/base.py
+++ b/src/surrantic/base.py
@@ -124,6 +124,8 @@ def _prepare_value(value: Any) -> str:
         return f"'{value.isoformat()}'"
     if isinstance(value, RecordID):
         return str(value)
+    if isinstance(value, BaseModel):
+        return json.dumps(value.model_dump())
     return json.dumps(value)
 
 def _prepare_data(obj: Any) -> str:


### PR DESCRIPTION
### Add Pydantic BaseModel serialization support

Previously, ObjectModel fields containing BaseModel instances would trigger a "Object is not JSON serializable" error, when trying to use the save method.
This PR adds native support for serializing Pydantic BaseModel instances in _prepare_value function 

Changes:
- Add BaseModel type check
- Use model_dump() for serialization
- Maintain existing behavior for other types